### PR TITLE
Fix author names in 2020-04-27-melhart20a

### DIFF
--- a/_posts/2020-04-27-melhart20a.md
+++ b/_posts/2020-04-27-melhart20a.md
@@ -20,8 +20,7 @@ lastpage: 34
 page: 27-34
 order: 27
 cycles: false
-bibtex_author: Melhart, David and Sfikas, Konstantinos and Giannakakis, Giorgos and
-  Liapis, Georgios Yannakakis Antonios
+bibtex_author: Melhart, David and Sfikas, Konstantinos and Giannakakis, Giorgos and Yannakakis, Georgios N. and Liapis, Antonios
 author:
 - given: David
   family: Melhart
@@ -29,7 +28,9 @@ author:
   family: Sfikas
 - given: Giorgos
   family: Giannakakis
-- given: Georgios Yannakakis Antonios
+- given: Georgios N.
+  family: Yannakakis
+- given: Antonios
   family: Liapis
 date: 2020-04-27
 address: 


### PR DESCRIPTION
Two of the author names were combined - probably a bug in the automation. The correct list is David Melhart, Konstantinos Sfikas, Giorgos Giannakakis, Georgios N. Yannakakis, and Antonios Liapis. The names are correct in the PDF.

https://proceedings.mlr.press/v86/melhart20a.html